### PR TITLE
Adding function returning all rows of RowSet

### DIFF
--- a/source/d2sqlite3.d
+++ b/source/d2sqlite3.d
@@ -1199,6 +1199,22 @@ struct RowSet
         else
             throw new SqliteException("no row available");
     }
+    
+    /++
+    Gets list of all rows
+    +/
+    @property Row[] all()
+    {
+        auto rowlist = appender!(Row[]);
+
+        while (!empty)
+        {
+            rowlist.put(front);
+            popFront();
+        }
+
+        return rowlist.data;
+    }
 }
 
 /++


### PR DESCRIPTION
Function "Row[] all()" returns array of all rows of query result. It could be useful in functions where we should return database query result. By now I need to return whole query structure or make row list by myself.
