### PR TITLE
Removed unnecessary reset()

### DIFF
--- a/source/d2sqlite3.d
+++ b/source/d2sqlite3.d
@@ -1071,7 +1071,6 @@ public:
         core.state = sqlite3_step(core.statement);
         if (core.state != SQLITE_ROW && core.state != SQLITE_DONE)
         {
-            reset(); // necessary to retrieve the error message.
             throw new SqliteException(errmsg(core.dbHandle), core.state);
         }
     }


### PR DESCRIPTION
Sorry for translate.google.
I'm not sure. But this seems to `reset ()` is not needed.
I use SQLite 3.8.7.1. When executes a query that violates the uniqueness constraint, Query.execute throws exception `SqliteException ("Could not reset the statement")`.
When I comment it received "error 19: UNIQUE constraint failed: services.n", as expected.
https://www.sqlite.org/c3ref/step.html says that reset () only for legacy functions (sqlite3_prepare () or sqlite3_prepare16 ()).
I hope to 0.5.2, if I'm right =).
Thanks.
