### PR TITLE
use sqlite3_close_v2 instead of sqlite3_close

### DIFF
--- a/source/d2sqlite3.d
+++ b/source/d2sqlite3.d
@@ -180,7 +180,7 @@ private:
         {
             if (handle)
             {
-                auto result = sqlite3_close(handle);
+                auto result = sqlite3_close_v2(handle);
                 enforce(result == SQLITE_OK, new SqliteException(errmsg(handle), result));
             }
             handle = null;
@@ -301,7 +301,7 @@ public:
     +/
     void close()
     {
-        check(sqlite3_close(handle));
+        check(sqlite3_close_v2(handle));
         p.handle = null;
     }
 


### PR DESCRIPTION
Use of sqlite3_close() will fail if any statements are left hanging around. As a result, it is impossible to reliably close the database if any statements are left for the garbage collector to clean up.

sqlite3_close_v2() is designed for this kind of scenario.