### PR TITLE
only linux has libdl

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,8 +15,8 @@ configuration "all-included" {
     libs "sqlite3" platform="windows"
     copyFiles "lib/win32/sqlite3.dll" platform="win32"
     copyFiles "lib/win64/sqlite3.dll" platform="win64"
-    
+
     preBuildCommands "make -C $PACKAGE_DIR -f sqlite3.mak" platform="posix"
     sourceFiles "sqlite3.o" platform="posix"
-    libs "dl" platform="posix"
+    libs "dl" platform="linux-gdc"
 }


### PR DESCRIPTION
- only gdc doesn't link against it by default (b/c of missing shared
  library support)
