### PR TITLE
reset the statement on error

### DIFF
--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -44,7 +44,6 @@ private:
 package(d2sqlite3):
     this(Statement statement)
     {
-        this.statement = statement;
         if (!statement.empty)
             state = sqlite3_step(statement.handle);
         else
@@ -56,6 +55,7 @@ package(d2sqlite3):
             throw new SqliteException(errmsg(statement.handle), state);
         }
 
+        this.statement = statement;
         colCount = sqlite3_column_count(statement.handle);
         current = Row(statement, colCount);
     }

--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -50,8 +50,11 @@ package(d2sqlite3):
         else
             state = SQLITE_DONE;
 
-        enforce(state == SQLITE_ROW || state == SQLITE_DONE,
-                new SqliteException(errmsg(statement.handle), state));
+        if (state != SQLITE_ROW && state != SQLITE_DONE)
+        {
+            statement.reset();
+            throw new SqliteException(errmsg(statement.handle), state);
+        }
 
         colCount = sqlite3_column_count(statement.handle);
         current = Row(statement, colCount);

--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -49,11 +49,8 @@ package(d2sqlite3):
         else
             state = SQLITE_DONE;
 
-        if (state != SQLITE_ROW && state != SQLITE_DONE)
-        {
-            statement.reset();
-            throw new SqliteException(errmsg(statement.handle), state);
-        }
+        enforce(state == SQLITE_ROW || state == SQLITE_DONE,
+                new SqliteException(errmsg(statement.handle), state));
 
         this.statement = statement;
         colCount = sqlite3_column_count(statement.handle);


### PR DESCRIPTION
Fount this in our multithread app when on
```
db.execute("BEGIN IMMEDIATE")
```

it can throw exception because of database is locked by other thread

But after that if one retry the call to the db, it ends up with `error: cannot commit transaction - SQL statements in progress`.

I found that it is because previous statement of `BEGIN IMMEDIATE` was not cleared.
With this change, it seems to work.