### PR TITLE
Adds support for bind/inject/peek JSONValue types

### DIFF
--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -19,6 +19,7 @@ import d2sqlite3.internal.util;
 
 import std.conv : to;
 import std.exception : enforce;
+import std.json : JSONValue;
 import std.string : format;
 import std.typecons : Nullable;
 
@@ -305,6 +306,14 @@ public:
     {
         assert(statement.handle, "operation on an empty statement");
         return (cast(const(char)*) sqlite3_column_text(statement.handle, internalIndex(index))).to!T;
+    }
+
+    /// ditto
+    T peek(T)(int index)
+        if (is(T == JSONValue))
+    {
+        import std.json : parseJSON;
+        return peek!string(index).parseJSON();
     }
 
     /// ditto

--- a/source/tests.d
+++ b/source/tests.d
@@ -441,6 +441,21 @@ unittest // Binding/peeking blob values
     }
 }
 
+unittest // Binding/peeking JSONValue values
+{
+    import std.json : JSONValue;
+
+    auto db = Database(":memory:");
+    db.execute("CREATE TABLE test (val TEXT)");
+
+    auto statement = db.prepare("INSERT INTO test (val) VALUES (?)");
+    JSONValue value = JSONValue([1]);
+    statement.inject(value);
+
+    auto results = db.execute("SELECT * FROM test");
+    assert(results.front.peek!JSONValue(0) == value);
+}
+
 unittest // Struct injecting
 {
     static struct Test


### PR DESCRIPTION
I was interested in taking a stab at supporting automatic JSON (de)serialization. Curious about your thoughts on something like this, as well as the implementation.

I'd add more tests if you're interested in merging