### PR TITLE
Add the unlocking facility using sqlite3_unlock_notify

### DIFF
--- a/sqlite3.mak
+++ b/sqlite3.mak
@@ -1,7 +1,7 @@
 all: sqlite3.o
 
 sqlite3.o: c/sqlite3.c
-	gcc -c -O2 -DSQLITE_ENABLE_COLUMN_METADATA c/sqlite3.c
+	gcc -c -O2 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_UNLOCK_NOTIFY c/sqlite3.c
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
This adds the possibility to handle database locks as described in https://www.sqlite.org/unlock_notify.html.

I've provided interface for custom implementations when other concurrency library is used (for example vibe-d) and implementation using Phobos library.

As unblock notify is not guaranteed to be compiled in, there is also a mechanism to simulate it on the sqlite instances that doesn't provide it.

For example this is the way how it is handled in .Net Core driver:
```C#
public static int sqlite3_step_blocking(Sqlite3Handle db, Sqlite3StmtHandle stmt, int milliseconds)
{
    var timer = new Stopwatch();
    int rc;
    timer.Start();
    while (SQLITE_LOCKED == (rc = sqlite3_step(stmt)))
    {
        if (timer.ElapsedMilliseconds >= milliseconds)
        {
            return rc;
        }
        sqlite3_reset(stmt);
        Thread.Sleep(150);
    }
}
```