### PR TITLE
fix UTF-8 handling in ByStatement.findEnd

### DIFF
--- a/source/d2sqlite3/internal/util.d
+++ b/source/d2sqlite3/internal/util.d
@@ -65,13 +65,14 @@ auto byStatement(string sql)
         {
             import std.algorithm : countUntil;
             import std.string : toStringz;
+            import std.utf : byCodeUnit;
 
             size_t pos;
             bool complete;
             do
             {
                 auto tail = sql[pos .. $];
-                immutable offset = tail.countUntil(';') + 1;
+                immutable offset = tail.byCodeUnit.countUntil(';') + 1;
                 pos += offset;
                 if (offset == 0)
                     pos = sql.length;

--- a/source/tests.d
+++ b/source/tests.d
@@ -816,5 +816,11 @@ unittest // CachedResults copies
 unittest // UTF-8
 {
     auto db = Database(":memory:");
-    db.run("SELECT '\u2019\u2019';");
+    bool ran = false;
+    db.run("SELECT '\u2019\u2019';", (ResultRange r) {
+        assert(r.oneValue!string == "\u2019\u2019");
+        ran = true;
+        return true;
+    });
+    assert(ran);
 }

--- a/source/tests.d
+++ b/source/tests.d
@@ -813,3 +813,8 @@ unittest // CachedResults copies
     assert(data[0][0].as!string == "ABC");
 }
 
+unittest // UTF-8
+{
+    auto db = Database(":memory:");
+    db.run("SELECT '\u2019\u2019';");
+}


### PR DESCRIPTION
`tail.countUntil(';')` counted code points, but pos is used as a number of
code units.

Prompted by https://forum.dlang.org/post/mailman.2321.1523383471.3374.digitalmars-d@puremagic.com