### PR TITLE
Always emit error codes to SqliteException

### DIFF
--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -941,7 +941,7 @@ public:
     /++
     Registers a delegate of type `TraceCallbackDelegate` as the trace callback.
 
-    Any previously set trace callback is released.
+    Any previously set profile or trace callback is released.
     Pass `null` to disable the callback.
 
     The string parameter that is passed to the callback is the SQL text of the statement being
@@ -967,7 +967,7 @@ public:
     /++
     Registers a delegate of type `ProfileCallbackDelegate` as the profile callback.
 
-    Any previously set profile callback is released.
+    Any previously set profile or trace callback is released.
     Pass `null` to disable the callback.
 
     The string parameter that is passed to the callback is the SQL text of the statement being

--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -1318,7 +1318,7 @@ Exception thrown when SQLite functions return an error.
 class SqliteException : Exception
 {
     /++
-    The _code of the error that raised the exception, or 0 if it's not an Sqlite error code.
+    The _code of the error that raised the exception
     +/
     int code;
 

--- a/source/d2sqlite3/library.d
+++ b/source/d2sqlite3/library.d
@@ -64,14 +64,14 @@ usually wouldn't be called. Use for instance before a call to config().
 +/
 void initialize()
 {
-    auto result = sqlite3_initialize();
-    enforce(result == SQLITE_OK, new SqliteException("Initialization: error %s".format(result)));
+    immutable result = sqlite3_initialize();
+    enforce(result == SQLITE_OK, new SqliteException("Initialization: error %s".format(result), result));
 }
 /// Ditto
 void shutdown()
 {
-    auto result = sqlite3_shutdown();
-    enforce(result == SQLITE_OK, new SqliteException("Shutdown: error %s".format(result)));
+    immutable result = sqlite3_shutdown();
+    enforce(result == SQLITE_OK, new SqliteException("Shutdown: error %s".format(result), result));
 }
 
 /++
@@ -84,8 +84,8 @@ See_Also: $(LINK http://www.sqlite.org/c3ref/config.html).
 +/
 void config(Args...)(int code, Args args)
 {
-    auto result = sqlite3_config(code, args);
-    enforce(result == SQLITE_OK, new SqliteException("Configuration: error %s".format(result)));
+    immutable result = sqlite3_config(code, args);
+    enforce(result == SQLITE_OK, new SqliteException("Configuration: error %s".format(result), result));
 }
 
 /++

--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -703,6 +703,10 @@ struct ColumnData
     Returns the data converted to T.
 
     If the data is NULL, defaultValue is returned.
+
+    Throws:
+        VariantException if the value cannot be converted
+        to the desired type.
     +/
     auto as(T)(T defaultValue = T.init)
         if (isBoolean!T || isNumeric!T || isSomeString!T)
@@ -724,12 +728,7 @@ struct ColumnData
         if (_type == SqliteType.NULL)
             return defaultValue;
 
-        Blob data;
-        try
-            data = _value.get!Blob;
-        catch (VariantException e)
-            throw new SqliteException("impossible to convert this column to a " ~ T.stringof, 0);
-
+        Blob data = _value.get!Blob;
         return cast(T) data;
     }
 

--- a/source/d2sqlite3/results.d
+++ b/source/d2sqlite3/results.d
@@ -728,7 +728,7 @@ struct ColumnData
         try
             data = _value.get!Blob;
         catch (VariantException e)
-            throw new SqliteException("impossible to convert this column to a " ~ T.stringof);
+            throw new SqliteException("impossible to convert this column to a " ~ T.stringof, 0);
 
         return cast(T) data;
     }

--- a/source/tests.d
+++ b/source/tests.d
@@ -460,7 +460,8 @@ unittest // Binding/peeking text values
     assert(results.front.peek!(string, PeekMode.copy)(0) == "I am a text.");
 
     import std.exception : assertThrown;
-    assertThrown!SqliteException(results.front[0].as!Blob);
+    import std.variant : VariantException;
+    assertThrown!VariantException(results.front[0].as!Blob);
 }
 
 unittest // Binding/peeking blob values

--- a/source/tests.d
+++ b/source/tests.d
@@ -886,3 +886,12 @@ unittest // UTF-8
     });
     assert(ran);
 }
+
+unittest // loadExtension failure test
+{
+    import std.algorithm : canFind;
+    import std.exception : collectExceptionMsg;
+    auto db = Database(":memory:");
+    auto msg = collectExceptionMsg(db.loadExtension("foobar"));
+    assert(msg.canFind("(not authorized)"));
+}

--- a/source/tests.d
+++ b/source/tests.d
@@ -317,11 +317,14 @@ unittest // Callbacks
 
     auto db = Database(":memory:");
     db.setTraceCallback((string s) { wasTraced = true; });
-    db.setProfileCallback((string s, ulong t) { wasProfiled = true; });
-    db.setProgressHandler(1, { hasProgressed = true; return 0; });
     db.execute("SELECT * FROM sqlite_master;");
     assert(wasTraced);
+    db.setProfileCallback((string s, ulong t) { wasProfiled = true; });
+    db.execute("SELECT * FROM sqlite_master;");
     assert(wasProfiled);
+
+    db.setProgressHandler(1, { hasProgressed = true; return 0; });
+    db.execute("SELECT * FROM sqlite_master;");
     assert(hasProgressed);
 }
 


### PR DESCRIPTION
I originally tried to change `get()` to throw a VariantException instead of SqliteException, but this would be a breaking change. So instead I opted for letting the error code == 0 if it's an error that is unrelated to Sqlite (because type conversion errors are unrelated to the C database routines).