### PR TITLE
Prepare many statements from a single string.

### DIFF
--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -344,6 +344,15 @@ SELECT 42; -- do this one
 		assert(!statements.empty);
 		statements.popFront();
 		assert(statements.empty);
+		int count = 4;
+		foreach(prep;db.prepare_many(q"[
+SELECT 3;
+SELECT 2;
+SELECT 1;
+-- contact!]")) {
+			--count;
+		}
+		assert(count == 0);
 	}
 
     /// Convenience functions equivalent to an SQL statement.

--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -278,10 +278,30 @@ public:
 
     The statement becomes invalid if the Database goes out of scope and is destroyed.
     +/
-    Statement prepare(string sql)
+    Statement prepare(const string sql)
     {
         return Statement(this, sql);
     }
+
+	/++
+	 Prepares (compiles) several SQL statements and return them.
+
+    The statements become invalid if the Database goes out of scope and is destroyed.
+    +/
+	struct PrepareMany {
+		Statement current;
+		string sql_left;
+		this() {
+			popFront();
+		}
+		void popFront() {
+			current = Statement(this, sql);
+		@property
+			Statement front() {
+		}
+	Range!Statement prepare_many(string sql)
+	{
+		
 
     /// Convenience functions equivalent to an SQL statement.
     void begin() { execute("BEGIN"); }

--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -18,9 +18,10 @@ import d2sqlite3.sqlite3;
 import d2sqlite3.internal.memory;
 import d2sqlite3.internal.util;
 
+import std.range.interfaces: Range;
 import std.conv : to;
 import std.exception : enforce;
-import std.string : format, toStringz;
+import std.string : format, toStringz, trim;
 import std.typecons : Nullable;
 
 /// Set _UnlockNotify version if compiled with SqliteEnableUnlockNotify or SqliteFakeUnlockNotify

--- a/source/d2sqlite3/database.d
+++ b/source/d2sqlite3/database.d
@@ -56,6 +56,27 @@ enum Deterministic
     no = 0
 }
 
+struct PrepareMany {
+	Database db;
+	Statement current;
+	string sql_left;
+	this(Database db, const string sql) {
+		this.db = db;
+		this.sql_left = sql.trim();
+		popFront();
+	}
+	void popFront() {
+		current = Statement(this, sql_left);
+		sql_left = sql_left.trim();
+	}
+	@property void empty() {
+		return sql_left.length == 0;
+	}
+	@property Statement front() {
+		return current;
+	}
+}
+
 /++
 An database connection.
 
@@ -288,19 +309,11 @@ public:
 
     The statements become invalid if the Database goes out of scope and is destroyed.
     +/
-	struct PrepareMany {
-		Statement current;
-		string sql_left;
-		this() {
-			popFront();
-		}
-		void popFront() {
-			current = Statement(this, sql);
-		@property
-			Statement front() {
-		}
+
 	Range!Statement prepare_many(string sql)
 	{
+		return PrepareMany(this, sql);
+	}
 		
 
     /// Convenience functions equivalent to an SQL statement.

--- a/source/d2sqlite3/statement.d
+++ b/source/d2sqlite3/statement.d
@@ -88,7 +88,7 @@ package(d2sqlite3):
 	this(Database db, const string sql)
 	{
 		string temp = sql;
-		this(temp);
+		this(db, temp);
 		// this constructor won't be able to give any indication that
 		// the sql wasn't fully parsed, so make sure it is.
 		assert(temp.length == 0);
@@ -99,8 +99,8 @@ package(d2sqlite3):
     this(Database db, ref string sql)
     {
         sqlite3_stmt* handle;
-		const byte* head = sql.toStringz;
-		const byte* tail = null;
+		immutable(char)* head = sql.toStringz;
+		immutable(char)* tail = null;
         version (_UnlockNotify)
         {
             auto result = sqlite3_blocking_prepare_v2(db, head, sql.length.to!int,
@@ -125,7 +125,7 @@ package(d2sqlite3):
 			 beginning of the second. This allows to prepare many ; delineated
 			 statements, without having to parse the SQL ourselves.
 			 +/
-			size head_length = tail - head;
+			size_t head_length = tail - head;
 			debug p.sql = sql[0..head_length];
 			sql = sql[head_length..$];
 		}

--- a/source/d2sqlite3/statement.d
+++ b/source/d2sqlite3/statement.d
@@ -89,14 +89,18 @@ package(d2sqlite3):
 	{
 		string temp = sql;
 		this(temp);
+		// this constructor won't be able to give any indication that
+		// the sql wasn't fully parsed, so make sure it is.
 		assert(temp.length == 0);
+		// the second constructor moves the sql parameter to the
+		// unparsed tail, so use that if you might be preparing 2 statements
 	}
 	
-    this(Database db, inout string sql)
+    this(Database db, ref string sql)
     {
         sqlite3_stmt* handle;
-		byte* head = sql.toStringz;
-		byte* tail = null;
+		const byte* head = sql.toStringz;
+		const byte* tail = null;
         version (_UnlockNotify)
         {
             auto result = sqlite3_blocking_prepare_v2(db, head, sql.length.to!int,

--- a/source/d2sqlite3/statement.d
+++ b/source/d2sqlite3/statement.d
@@ -114,6 +114,13 @@ package(d2sqlite3):
 			debug p.sql = sql;
 			sql = "";
 		} else {
+			/++
+			 the tail will be 1 past the end of the SQL statement that was just
+			 prepared. So if you prepare a string with two SQL statements,
+			 it will prepare the first statement, then set tail at the
+			 beginning of the second. This allows to prepare many ; delineated
+			 statements, without having to parse the SQL ourselves.
+			 +/
 			size head_length = tail - head;
 			debug p.sql = sql[0..head_length];
 			sql = sql[head_length..$];


### PR DESCRIPTION
sqlite3_prepare_v2 provides a tail parameter, and I figured out the trick with it a while ago. It sets tail to the point that it stops being able to parse, which is helpful for showing where your error is in your SQL statement, but it's also helpful for parsing multiple SQL statements. sqlite3_prepare only prepares the first, then "fails" at the beginning of the second statement right after the semicolon, which lets one prepare many statements from a single string. So that's what I did. Hope you like it!