### PR TITLE
Statement: Avoid allocation in prepare

### DIFF
--- a/source/d2sqlite3/statement.d
+++ b/source/d2sqlite3/statement.d
@@ -88,14 +88,15 @@ package(d2sqlite3):
     this(Database db, string sql)
     {
         sqlite3_stmt* handle;
+        enforce(sql.length <= int.max, "Length of SQL statement exceeds `int.max`");
         version (_UnlockNotify)
         {
-            auto result = sqlite3_blocking_prepare_v2(db, sql.toStringz, sql.length.to!int,
+            auto result = sqlite3_blocking_prepare_v2(db, sql.ptr, cast(int) sql.length,
                 &handle, null);
         }
         else
         {
-            auto result = sqlite3_prepare_v2(db.handle(), sql.toStringz, sql.length.to!int,
+            auto result = sqlite3_prepare_v2(db.handle(), sql.ptr, cast(int) sql.length,
                 &handle, null);
         }
         enforce(result == SQLITE_OK, new SqliteException(errmsg(db.handle()), result, sql));


### PR DESCRIPTION
The allocation was duplicating the full statement,
then using the length minus the final `\0`.
However, the [documentation](https://www.sqlite.org/c3ref/prepare.html) states:

> If the nByte argument is negative, then zSql is read up to the first zero terminator.
> If nByte is positive, then it is the number of bytes read from zSql.
> If nByte is zero, then no prepared statement is generated.
> If the caller knows that the supplied string is nul-terminated, then there is a small performance advantage
> to passing an nByte parameter that is the number of bytes in the input string including the nul-terminator.

We should either include the terminating `\0` in nByte or give the string length directly.
Since the GC allocation is likely to be much more expensive than whatever sqlite3 is doing,
we go with the second option.